### PR TITLE
Update README.md to replace Golang with Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # :fire:Flamepool:fire:  
 
 # What is Flamepool?
-Flamepool is a worker pool implementation for Golang inspired on the thread pool pattern.
+Flamepool is a worker pool implementation for Go inspired on the thread pool pattern.
 # Installation
 > go get github.com/mercadolibre/flamepool
 


### PR DESCRIPTION
This change updates the README.md file to correct the name of the language from Golang to Go. This is called out in the FAQ:

- https://golang.org/doc/faq#go_or_golang