### PR TITLE
Added Close() function to free pool resources 

### DIFF
--- a/flamepool.go
+++ b/flamepool.go
@@ -3,7 +3,6 @@ package flamepool
 import (
 	"errors"
 	"reflect"
-	"runtime"
 )
 
 // Pool Task
@@ -42,13 +41,6 @@ func newPool(poolSize int, items interface{}) *Pool {
 	pool.errorChan = make(chan error, len(pool.elements))
 	pool.innerChan = make(chan interface{}, len(pool.elements))
 
-	runtime.SetFinalizer(pool, func(p *Pool) {
-		// Close all channels from pool on garbage collection
-		close(p.resultChan)
-		close(p.errorChan)
-		close(p.innerChan)
-	})
-
 	return pool
 }
 
@@ -68,4 +60,11 @@ func (pool *Pool) ChangeSettings(poolSize int, items interface{}) {
 	newPool := newPool(poolSize, items)
 
 	*pool = *newPool
+}
+
+// Close Closes all channels and resources associated with pool
+func (pool *Pool) Close() {
+	close(pool.resultChan)
+	close(pool.errorChan)
+	close(pool.innerChan)
 }

--- a/flamepool.go
+++ b/flamepool.go
@@ -3,6 +3,7 @@ package flamepool
 import (
 	"errors"
 	"reflect"
+	"runtime"
 )
 
 // Pool Task
@@ -40,6 +41,13 @@ func newPool(poolSize int, items interface{}) *Pool {
 	pool.resultChan = make(chan interface{}, len(pool.elements))
 	pool.errorChan = make(chan error, len(pool.elements))
 	pool.innerChan = make(chan interface{}, len(pool.elements))
+
+	runtime.SetFinalizer(pool, func(p *Pool) {
+		// Close all channels from pool on garbage collection
+		close(p.resultChan)
+		close(p.errorChan)
+		close(p.innerChan)
+	})
 
 	return pool
 }

--- a/flamepool_test.go
+++ b/flamepool_test.go
@@ -165,6 +165,21 @@ func TestResultChannelReception(t *testing.T) {
 	}
 }
 
+func TestClose(t *testing.T) {
+	elements := []string{"rulo", "tomcat"}
+	pool := New(1, elements)
+
+	pool.Close()
+
+	select {
+	case <-pool.errorChan:
+	case <-pool.innerChan:
+	case <-pool.resultChan:
+	default:
+		t.Error("Channels should be closed")
+	}
+}
+
 type FooTaskAlwaysDoError struct{}
 
 func (ft FooTaskAlwaysDoError) Do(element interface{}) (interface{}, error) {


### PR DESCRIPTION
Given current pool implementation, on long running processes if no new task is sent or if the GC doesn't run, a go routine leak occurs caused by workers expecting task from pool's inner channel.

This can be solved by closing all channels on a Finalizer associated to the pool, but on long running programs the GC isn't guaranteed to run on a timely manner to close all channels, thus causing a go routine leak.

So a second option was opted where a Close() function was implemented to free all resources associated with the pool.